### PR TITLE
Add AgentCanvas (Automating the Design of Embodied Agent Architectures) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Self-improvement loops grounded in visual, simulated, or embodied environments.
 - [JARVIS-1: Open-World Multi-task Agents with Memory-Augmented Multimodal Language Models](https://arxiv.org/abs/2311.05997) (arXiv 2023) [[code](https://github.com/CraftJarvis/JARVIS-1)] - Uses multimodal memory and planning for open-world Minecraft agents that improve across tasks.
 - [SRUM: Fine-Grained Self-Rewarding for Unified Multimodal Models](https://arxiv.org/abs/2510.12784) (arXiv 2025) - Applies self-rewarding post-training to unified multimodal models.
 - [SIMA 2: A Generalist Embodied Agent for Virtual Worlds](https://arxiv.org/abs/2512.04797) (arXiv 2025) - Pairs a Gemini reasoning core with self-generated tasks and rewards so an embodied agent can learn new skills in new 3D worlds without human demonstrations.
+- [Automating the Design of Embodied Agent Architectures](https://jianzhou0420.github.io/src/works/AgentCanvas/paper.html) (arXiv 2026) [[code](https://github.com/jianzhou0420/AgentCanvas)] - Introduces AgentCanvas and KDLoop for searching embodied agent architectures as editable typed graphs through coding-agent proposal, critique, experimentation, and distillation.
 
 ## Frameworks and Implementations
 


### PR DESCRIPTION
### Motivation
- Add a primary-source entry for "Automating the Design of Embodied Agent Architectures" (AgentCanvas) to the "Multimodal and Embodied Self-Improvement" section so the list includes a recent arXiv project that studies coding-agent-driven architecture search over editable embodied-agent graphs and documents both improvements and notable failure modes.

### Description
- Inserted one formatted README line linking the project page and arXiv (`arXiv 2026`) and an official `[[code](https://github.com/jianzhou0420/AgentCanvas)]` link, following the repository's exact entry format; Codex was used to read the contribution rules, validate placement and formatting against the checklist, canonicalise URLs, run checks, and programmatically apply the README edit and prepare the PR metadata.

### Testing
- Ran `npm run lint` (markdownlint + Prettier) and `node scripts/link-check.mjs`, both of which passed locally, and attempted `CHECK_LINKS=1 node scripts/link-check.mjs` which performed a network check but reported external link fetch failures for many pre-existing README links in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e430b92048328abf4b3f11515a80d)